### PR TITLE
Implement LayerEngine and battle stage setup

### DIFF
--- a/engines/AssetLoader.js
+++ b/engines/AssetLoader.js
@@ -1,12 +1,28 @@
 export class AssetLoader {
     constructor() {
         this.images = {};
+        this.promises = [];
     }
 
     loadImage(key, src) {
-        // placeholder for real loading logic
-        console.log(`Loading image: ${key} from ${src}`);
-        return Promise.resolve();
+        const promise = new Promise((resolve, reject) => {
+            const img = new Image();
+            img.onload = () => {
+                this.images[key] = img;
+                console.log(`Image loaded: ${key}`);
+                resolve(img);
+            };
+            img.onerror = () => {
+                console.error(`Failed to load image: ${src}`);
+                reject(`Failed to load image: ${src}`);
+            };
+            img.src = src;
+        });
+        this.promises.push(promise);
+    }
+
+    loadAll() {
+        return Promise.all(this.promises);
     }
 
     getImage(key) {

--- a/engines/BattleStageManager.js
+++ b/engines/BattleStageManager.js
@@ -1,0 +1,14 @@
+export class BattleStageManager {
+    constructor() {
+        this.currentStage = null;
+    }
+
+    loadStage(stageData) {
+        this.currentStage = stageData;
+        console.log(`Stage loaded: ${this.currentStage.name}`);
+    }
+
+    getBackgroundImage() {
+        return this.currentStage ? this.currentStage.backgroundImage : null;
+    }
+}

--- a/engines/GameEngine.js
+++ b/engines/GameEngine.js
@@ -1,21 +1,24 @@
 import { LoopEngine } from './LoopEngine.js';
+import { LayerEngine } from './LayerEngine.js';
 import { RendererEngine } from './RendererEngine.js';
 import { GridEngine } from './GridEngine.js';
 import { AssetLoader } from './AssetLoader.js';
-import { TurnEngine } from './TurnEngine.js';
+import { BattleStageManager } from './BattleStageManager.js';
 
 export class GameEngine {
     constructor() {
-        console.log('Game Engine is booting up...');
+        console.log("Game Engine is booting up...");
         this.initialize();
     }
 
     initialize() {
         const gameBoard = document.getElementById('game-board');
-        this.gridEngine = new GridEngine(20, 15);
-        this.rendererEngine = new RendererEngine(gameBoard);
+
+        this.layerEngine = new LayerEngine(gameBoard);
+        this.rendererEngine = new RendererEngine(this.layerEngine);
+        this.gridEngine = new GridEngine(16, 9);
         this.assetLoader = new AssetLoader();
-        this.turnEngine = new TurnEngine();
+        this.stageManager = new BattleStageManager();
 
         this.loopEngine = new LoopEngine(
             (deltaTime) => this.update(deltaTime),
@@ -23,17 +26,32 @@ export class GameEngine {
         );
     }
 
-    start() {
+    async start() {
+        this.layerEngine.initialize();
+
+        this.assetLoader.loadImage('stageArena', 'assets/images/stage/battle-stage-arena.png');
+        await this.assetLoader.loadAll();
+        console.log("All assets loaded!");
+
+        this.stageManager.loadStage({
+            name: 'Arena',
+            backgroundImage: 'stageArena'
+        });
+
+        const bgImage = this.assetLoader.getImage(this.stageManager.getBackgroundImage());
+        this.rendererEngine.drawBackgroundImage(bgImage);
+
         this.gridEngine.createGrid();
         this.rendererEngine.drawGrid(this.gridEngine.getGrid());
+
         this.loopEngine.start();
     }
 
     update(deltaTime) {
-        // future game logic will go here
+        // (업데이트 로직)
     }
 
     draw() {
-        // future rendering logic will go here
+        // (그리기 로직)
     }
 }

--- a/engines/GridEngine.js
+++ b/engines/GridEngine.js
@@ -1,5 +1,5 @@
 export class GridEngine {
-    constructor(width, height) {
+    constructor(width = 16, height = 9) {
         this.width = width;
         this.height = height;
         this.grid = [];
@@ -13,7 +13,7 @@ export class GridEngine {
             }
             this.grid.push(row);
         }
-        console.log('Grid created:', this.grid);
+        console.log(`Grid created with size: ${this.width}x${this.height}`);
     }
 
     getGrid() {

--- a/engines/LayerEngine.js
+++ b/engines/LayerEngine.js
@@ -1,0 +1,22 @@
+export class LayerEngine {
+    constructor(containerElement) {
+        this.container = containerElement;
+        this.layers = {};
+        this.layerOrder = ['background', 'grid', 'units', 'effects', 'ui'];
+    }
+
+    initialize() {
+        this.layerOrder.forEach(layerName => {
+            const layerElement = document.createElement('div');
+            layerElement.id = `${layerName}-layer`;
+            layerElement.className = 'layer';
+            this.container.appendChild(layerElement);
+            this.layers[layerName] = layerElement;
+        });
+        console.log('All layers initialized.');
+    }
+
+    getLayer(name) {
+        return this.layers[name];
+    }
+}

--- a/engines/RendererEngine.js
+++ b/engines/RendererEngine.js
@@ -1,27 +1,26 @@
 export class RendererEngine {
-    constructor(gameBoardElement) {
-        this.gameBoard = gameBoardElement;
+    constructor(layerEngine) {
+        this.layerEngine = layerEngine;
     }
 
-    createVisualElement(id, className, gridX, gridY) {
-        const element = document.createElement('div');
-        element.id = id;
-        element.className = className;
-        this.gameBoard.appendChild(element);
-        this.updatePosition(element, gridX, gridY);
-        return element;
+    drawBackgroundImage(image) {
+        const backgroundLayer = this.layerEngine.getLayer('background');
+        backgroundLayer.style.backgroundImage = `url(${image.src})`;
     }
 
-    updatePosition(element, gridX, gridY, gridSize = 32) {
-        const x = gridX * gridSize;
-        const y = gridY * gridSize;
-        element.style.transform = `translate(${x}px, ${y}px)`;
-    }
+    drawGrid(grid, gridSize = 48) {
+        const gridLayer = this.layerEngine.getLayer('grid');
+        const gridContainer = document.createElement('div');
+        gridContainer.id = 'grid-container';
+        gridLayer.appendChild(gridContainer);
 
-    drawGrid(grid) {
         grid.forEach((row, y) => {
             row.forEach((tile, x) => {
-                this.createVisualElement(`tile_${x}_${y}`, `tile ${tile.type}`, x, y);
+                const element = document.createElement('div');
+                element.className = `tile ${tile.type}`;
+                element.style.gridColumnStart = x + 1;
+                element.style.gridRowStart = y + 1;
+                gridContainer.appendChild(element);
             });
         });
     }

--- a/style.css
+++ b/style.css
@@ -3,13 +3,51 @@ body {
     color: #eee;
     text-align: center;
     font-family: sans-serif;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+    margin: 0;
 }
 
 #game-board {
     position: relative;
-    width: 640px;
-    height: 480px;
+    width: 800px;
+    height: 450px;
     border: 2px solid #eee;
-    background-color: #555;
-    margin: 20px auto;
+    background-color: #000;
+    overflow: hidden;
+}
+
+.layer {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
+
+#background-layer {
+    background-size: cover;
+    background-position: center;
+}
+
+#grid-layer {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+#grid-container {
+    display: grid;
+    width: 95%;
+    height: 95%;
+    grid-template-columns: repeat(16, 1fr);
+    grid-template-rows: repeat(9, 1fr);
+}
+
+.tile {
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    box-sizing: border-box;
 }


### PR DESCRIPTION
## Summary
- add LayerEngine and BattleStageManager for basic stage handling
- upgrade AssetLoader with real image loading
- set GridEngine default grid size to 16x9
- update RendererEngine to draw background and grid with layers
- enhance GameEngine to orchestrate stage setup using new engines
- apply new styles for layers and centered grid

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e11210b0c8327b605b971e001774a