### PR TITLE
Add GitHub Pages workflow and README

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,21 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/configure-pages@v3
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: '.'
+      - uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# DOM SRPG
+
+This project contains a small strategy RPG prototype built with plain DOM elements. The code is meant to run directly in a browser and can be served as a static site.
+
+## Running locally
+
+Use a simple HTTP server (for example Python's built-in server) to test the game:
+
+```bash
+python3 -m http.server 8080
+```
+
+Open <http://localhost:8080> in a browser.
+
+## Deploying with GitHub Pages
+
+GitHub Pages can host the game directly from the repository. The included workflow `deploy-pages.yml` deploys the contents of the repository whenever changes are pushed to the `main` branch. Enable GitHub Pages in the repository settings and choose **GitHub Actions** as the source.
+
+Once enabled, the game will be available at:
+
+```
+https://<your-username>.github.io/DOM-srpg/
+```
+
+If you encounter a `404` message, ensure that Pages is enabled and the deployment succeeded.


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to deploy to Pages
- document local testing and Pages deployment steps

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_687e1734cc90832787e80b115c696922