### PR TITLE
Add stage and layer modules

### DIFF
--- a/BattleStageManager.js
+++ b/BattleStageManager.js
@@ -1,0 +1,22 @@
+// BattleStageManager.js
+
+class BattleStageManager {
+    constructor(containerId) {
+        this.container = document.getElementById(containerId);
+    }
+
+    // 지정된 배경 이미지로 스테이지를 설정합니다.
+    setupStage(imageUrl) {
+        if (!this.container) {
+            console.error("Stage container not found!");
+            return;
+        }
+        this.container.style.backgroundImage = `url(${imageUrl})`;
+        this.container.style.backgroundSize = 'cover';
+        this.container.style.backgroundPosition = 'center';
+
+        console.log(`Stage background set to: ${imageUrl}`);
+    }
+}
+
+export default BattleStageManager;

--- a/LayerEngine.js
+++ b/LayerEngine.js
@@ -1,0 +1,76 @@
+// LayerEngine.js
+
+class LayerEngine {
+    constructor(containerId) {
+        this.container = document.getElementById(containerId);
+        if (!this.container) {
+            throw new Error(`Container with id '${containerId}' not found.`);
+        }
+        this.layers = {};
+    }
+
+    /**
+     * 새로운 레이어를 생성하고 컨테이너에 추가합니다.
+     * @param {string} layerName - 레이어의 이름 (예: 'grid', 'unit', 'effect')
+     * @param {number} zIndex - 레이어의 쌓임 순서 (CSS z-index)
+     * @returns {HTMLElement} 생성된 레이어 요소
+     */
+    createLayer(layerName, zIndex) {
+        if (this.layers[layerName]) {
+            return this.layers[layerName]; // 이미 존재하면 반환
+        }
+
+        const layer = document.createElement('div');
+        layer.id = `${layerName}-layer`;
+        layer.style.position = 'absolute';
+        layer.style.top = '0';
+        layer.style.left = '0';
+        layer.style.width = '100%';
+        layer.style.height = '100%';
+        layer.style.zIndex = zIndex;
+
+        this.container.appendChild(layer);
+        this.layers[layerName] = layer;
+
+        return layer;
+    }
+
+    /**
+     * 특정 레이어를 가져옵니다.
+     * @param {string} layerName - 가져올 레이어의 이름
+     * @returns {HTMLElement | undefined} 해당 레이어 요소
+     */
+    getLayer(layerName) {
+        return this.layers[layerName];
+    }
+
+    /**
+     * 16x9 그리드 레이어를 생성합니다.
+     * 컨테이너보다 약간 작게 만들어 체력바 등이 잘리지 않도록 합니다.
+     */
+    createGridLayer() {
+        const gridLayer = this.createLayer('grid', 10);
+
+        // 컨테이너보다 가로/세로 95% 크기로 설정하고 중앙 정렬
+        gridLayer.style.width = '95%';
+        gridLayer.style.height = '95%';
+        gridLayer.style.top = '2.5%';
+        gridLayer.style.left = '2.5%';
+
+        // 그리드 레이아웃 설정
+        gridLayer.style.display = 'grid';
+        gridLayer.style.gridTemplateColumns = 'repeat(16, 1fr)';
+        gridLayer.style.gridTemplateRows = 'repeat(9, 1fr)';
+
+        // 개발 중 그리드를 시각적으로 확인하기 위한 셀(cell) 생성 (선택 사항)
+        for (let i = 0; i < 16 * 9; i++) {
+            const cell = document.createElement('div');
+            // cell.style.border = '1px solid rgba(255, 255, 255, 0.2)'; // 그리드 선
+            gridLayer.appendChild(cell);
+        }
+
+        console.log("16x9 grid layer created.");
+    }
+}
+
+export default LayerEngine;

--- a/game.js
+++ b/game.js
@@ -1,6 +1,19 @@
 import GameEngine from './GameEngine.js';
+import BattleStageManager from './BattleStageManager.js';
+import LayerEngine from './LayerEngine.js';
 
 const game = new GameEngine();
 
 game.init();
+
 game.start();
+
+// Set up stage background
+const stageManager = new BattleStageManager('game-container');
+stageManager.setupStage('assets/images/stage/battle-stage-arena.png');
+
+// Set up layers (grid, unit, effect)
+const layerEngine = new LayerEngine('game-container');
+layerEngine.createGridLayer();
+layerEngine.createLayer('unit', 20);
+layerEngine.createLayer('effect', 30);


### PR DESCRIPTION
## Summary
- implement `BattleStageManager` for setting stage backgrounds
- create `LayerEngine` for managing DOM layers and a 16x9 grid
- update `game.js` to initialize stage and layers

## Testing
- `node -v`
- `node -e "const { default: Stage } = await import('./BattleStageManager.js'); console.log(typeof Stage);"`
- `node -e "import StageManager from './BattleStageManager.js'; import LayerEngine from './LayerEngine.js'; console.log('StageManager', typeof StageManager); console.log('LayerEngine', typeof LayerEngine);"`


------
https://chatgpt.com/codex/tasks/task_e_687e1c76f5588327b4ea95600eb45b3a