### PR TITLE
Add core event, pathfinding, and target modules

### DIFF
--- a/src/engine/EventEngine.js
+++ b/src/engine/EventEngine.js
@@ -1,0 +1,39 @@
+// src/engine/EventEngine.js
+
+/**
+ * 게임 내 모든 시스템 간의 통신을 중재하는 이벤트 방송국 역할을 합니다.
+ * 이를 통해 각 시스템은 서로를 직접 알 필요 없이 소통할 수 있습니다. (디커플링)
+ */
+class EventEngine {
+    constructor() {
+        this.listeners = new Map();
+    }
+
+    /**
+     * 특정 이벤트가 발생했을 때 실행할 함수(리스너)를 등록합니다.
+     * @param {string} eventName - 이벤트 이름 (예: 'unitAttacked')
+     * @param {Function} callback - 실행될 콜백 함수
+     */
+    on(eventName, callback) {
+        if (!this.listeners.has(eventName)) {
+            this.listeners.set(eventName, []);
+        }
+        this.listeners.get(eventName).push(callback);
+    }
+
+    /**
+     * 특정 이벤트를 모든 리스너에게 방송(trigger)합니다.
+     * @param {string} eventName - 방송할 이벤트 이름
+     * @param {*} data - 이벤트와 함께 전달할 데이터
+     */
+    emit(eventName, data) {
+        if (this.listeners.has(eventName)) {
+            console.log(`[EventEngine] 이벤트 방송: "${eventName}"`, data);
+            this.listeners.get(eventName).forEach(callback => callback(data));
+        }
+    }
+}
+
+// 이 엔진은 게임 전체에서 단 하나만 존재해야 하므로, 싱글턴 패턴으로 인스턴스를 export 합니다.
+const eventEngine = new EventEngine();
+export default eventEngine;

--- a/src/engine/PathfinderEngine.js
+++ b/src/engine/PathfinderEngine.js
@@ -1,0 +1,23 @@
+// src/engine/PathfinderEngine.js
+
+/**
+ * 그리드 기반의 경로 탐색을 담당합니다.
+ * A* 알고리즘 등을 사용하여 최적의 경로를 계산합니다.
+ */
+class PathfinderEngine {
+    /**
+     * 시작 지점부터 목표 지점까지의 경로를 찾습니다.
+     * @param {object} startPos - 시작 좌표 { col, row }
+     * @param {object} endPos - 목표 좌표 { col, row }
+     * @param {object} grid - 현재 그리드 데이터
+     * @returns {Array<object> | null} 경로 좌표의 배열 또는 null
+     */
+    findPath(startPos, endPos, grid) {
+        // (경로 탐색 알고리즘은 매우 복잡하므로 나중에 구현합니다)
+        console.log(`[PathfinderEngine] (${startPos.col},${startPos.row}) 에서 (${endPos.col},${endPos.row}) 까지의 경로를 탐색합니다.`);
+        // 지금은 임시로 경로를 찾지 못했다고 가정합니다.
+        return null;
+    }
+}
+
+export default PathfinderEngine;

--- a/src/manager/TargetManager.js
+++ b/src/manager/TargetManager.js
@@ -1,0 +1,34 @@
+// src/manager/TargetManager.js
+
+/**
+ * AI의 타겟팅 관련 로직을 처리합니다.
+ * 다양한 조건에 맞는 유닛을 찾아 반환하는 역할을 합니다.
+ */
+class TargetManager {
+    /**
+     * 특정 유닛에게서 가장 가까운 적을 찾습니다.
+     * @param {object} currentUnit - 기준이 되는 유닛
+     * @param {Array<object>} enemyUnits - 대상이 되는 적 유닛 목록
+     * @returns {object | null} 가장 가까운 적 유닛 또는 null
+     */
+    findNearestEnemy(currentUnit, enemyUnits) {
+        // (구현 로직은 나중에 추가합니다)
+        console.log(`[TargetManager] ${currentUnit.name}의 가장 가까운 적을 탐색합니다.`);
+        // 지금은 임시로 첫 번째 적을 반환합니다.
+        return enemyUnits.length > 0 ? enemyUnits[0] : null;
+    }
+
+    /**
+     * 체력이 가장 낮은 적을 찾습니다.
+     * @param {Array<object>} enemyUnits - 대상이 되는 적 유닛 목록
+     * @returns {object | null} 체력이 가장 낮은 적 유닛 또는 null
+     */
+    findLowestHealthEnemy(enemyUnits) {
+        // (구현 로직은 나중에 추가합니다)
+        console.log(`[TargetManager] 체력이 가장 낮은 적을 탐색합니다.`);
+        // 지금은 임시로 첫 번째 적을 반환합니다.
+        return enemyUnits.length > 0 ? enemyUnits[0] : null;
+    }
+}
+
+export default TargetManager;


### PR DESCRIPTION
## Summary
- add `EventEngine` singleton to broadcast events
- stub out `PathfinderEngine` for path calculations
- add `TargetManager` to manage AI targeting logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687e9c17716c83279303a930f795df50