### PR TITLE
Add basic behavior tree and integrate AI nodes

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,6 +1,5 @@
 // game.js
-
-// 기존 import 구문들
+// ... (기존 import 구문들)
 import GameEngine from './src/engine/GameEngine.js';
 import BattleStageManager from './src/manager/BattleStageManager.js';
 import LayerEngine from './src/engine/LayerEngine.js';
@@ -8,8 +7,8 @@ import LayerEngine from './src/engine/LayerEngine.js';
 // 새로 만든 엔진과 매니저들을 import 합니다.
 import UnitEngine from './src/engine/UnitEngine.js';
 import FormationEngine from './src/engine/FormationEngine.js';
-// AI 매니저를 불러옵니다.
 import AIManager from './src/ai/AIManager.js';
+import eventEngine from './src/engine/EventEngine.js'; // 이벤트 엔진 import
 
 // --- 게임 초기화 및 시작 ---
 const game = new GameEngine();
@@ -20,7 +19,7 @@ game.start();
 const stageManager = new BattleStageManager('game-container');
 const layerEngine = new LayerEngine('game-container');
 const unitEngine = new UnitEngine();
-const aiManager = new AIManager(); // AI 매니저 생성
+const aiManager = new AIManager();
 
 // --- 스테이지 및 레이어 설정 ---
 stageManager.setupStage('assets/images/stage/battle-stage-arena.png');
@@ -32,28 +31,30 @@ layerEngine.createLayer('effect', 30);
 // --- 포메이션 엔진을 사용하여 유닛 배치 ---
 const formationEngine = new FormationEngine(unitLayer, gridLayer);
 
-// 1. 워리어 유닛 인스턴스 생성
+// 유닛 생성
 const warrior = unitEngine.createUnit('class', 'warrior');
-if (warrior) {
-    aiManager.registerUnit(warrior); // 워리어를 AI 매니저에 등록
-    formationEngine.placeUnit(warrior, 'assets/images/unit/warrior.png', 1, 4);
-}
-
-// 3. 좀비 유닛 인스턴스 생성
 const zombie = unitEngine.createUnit('monster', 'zombie');
-if (zombie) {
-    aiManager.registerUnit(zombie); // 좀비를 AI 매니저에 등록
+
+// AI 등록 시 적군 목록을 함께 넘겨줍니다.
+if (warrior && zombie) {
+    aiManager.registerUnit(warrior, [zombie]);
+    aiManager.registerUnit(zombie, [warrior]);
+    
+    formationEngine.placeUnit(warrior, 'assets/images/unit/warrior.png', 1, 4);
     formationEngine.placeUnit(zombie, 'assets/images/unit/zombie.png', 14, 4);
 }
 
-// --- 예시: AI 턴 처리 ---
-const allUnits = [warrior, zombie].filter(Boolean);
-const enemyOfWarrior = [zombie].filter(Boolean);
-const enemyOfZombie = [warrior].filter(Boolean);
+// (예시) 이벤트 리스너 등록
+eventEngine.on('unitAttacked', (data) => {
+    console.log(`%c[Event] ${data.attacker.name}이(가) ${data.target.name}을(를) 공격했습니다!`, "color: orange; font-weight: bold;");
+    // 이벤트를 받아서 UI에 데미지를 표시하거나, 유닛의 HP를 깎는 로직을 여기에 추가할 수 있습니다.
+});
 
+// --- (예시) 턴 실행 ---
+console.log("\n--- 전투 시작 ---");
 if (warrior) {
-    aiManager.updateBlackboard(warrior, allUnits, enemyOfWarrior);
+    aiManager.executeTurn(warrior.id); // 워리어 턴 실행
 }
 if (zombie) {
-    aiManager.updateBlackboard(zombie, allUnits, enemyOfZombie);
+    aiManager.executeTurn(zombie.id); // 좀비 턴 실행
 }

--- a/src/ai/nodes/AttackTargetNode.js
+++ b/src/ai/nodes/AttackTargetNode.js
@@ -1,0 +1,30 @@
+// src/ai/nodes/AttackTargetNode.js
+
+import Node, { NodeState } from './Node.js';
+import eventEngine from '../../engine/EventEngine.js';
+
+/**
+ * 블랙보드에 저장된 타겟을 공격하는 행동 노드입니다.
+ */
+class AttackTargetNode extends Node {
+    evaluate(unit, blackboard) {
+        const target = blackboard.get('currentTargetUnit');
+        if (!target) {
+            return NodeState.FAILURE; // 타겟이 없으면 공격 실패
+        }
+
+        // TODO: 실제 사거리 체크 로직 구현 필요
+        const isInRange = true; // 지금은 무조건 사거리 안에 있다고 가정
+
+        if (isInRange) {
+            console.log(`[AI Node] ${unit.name}: ${target.name}을(를) 공격합니다!`);
+            // EventEngine을 통해 공격 이벤트를 방송합니다.
+            eventEngine.emit('unitAttacked', { attacker: unit, target: target });
+            return NodeState.SUCCESS;
+        } else {
+            return NodeState.FAILURE;
+        }
+    }
+}
+
+export default AttackTargetNode;

--- a/src/ai/nodes/FindTargetNode.js
+++ b/src/ai/nodes/FindTargetNode.js
@@ -1,0 +1,40 @@
+// src/ai/nodes/FindTargetNode.js
+
+import Node, { NodeState } from './Node.js';
+
+/**
+ * 특정 전략에 따라 타겟을 찾아 블랙보드에 저장하는 행동 노드입니다.
+ */
+class FindTargetNode extends Node {
+    /**
+     * @param {TargetManager} targetManager - 타겟을 찾기 위한 매니저
+     * @param {string} strategy - 타겟 탐색 전략 ('lowestHealth' 또는 'nearest')
+     * @param {Array<object>} enemyUnits - 적 유닛 목록
+     */
+    constructor(targetManager, strategy, enemyUnits) {
+        super();
+        this.targetManager = targetManager;
+        this.strategy = strategy;
+        this.enemyUnits = enemyUnits;
+    }
+
+    evaluate(unit, blackboard) {
+        let target = null;
+        if (this.strategy === 'lowestHealth') {
+            target = this.targetManager.findLowestHealthEnemy(this.enemyUnits);
+        } else if (this.strategy === 'nearest') {
+            target = this.targetManager.findNearestEnemy(unit, this.enemyUnits);
+        }
+
+        if (target) {
+            blackboard.set('currentTargetUnit', target);
+            console.log(`[AI Node] ${unit.name}: 타겟 설정 (${this.strategy}) -> ${target.name}`);
+            return NodeState.SUCCESS;
+        } else {
+            console.log(`[AI Node] ${unit.name}: 타겟을 찾지 못했습니다 (${this.strategy}).`);
+            return NodeState.FAILURE;
+        }
+    }
+}
+
+export default FindTargetNode;

--- a/src/ai/nodes/MoveToTargetNode.js
+++ b/src/ai/nodes/MoveToTargetNode.js
@@ -1,0 +1,31 @@
+// src/ai/nodes/MoveToTargetNode.js
+
+import Node, { NodeState } from './Node.js';
+
+/**
+ * 블랙보드에 저장된 타겟에게 이동하는 행동 노드입니다.
+ * 지금은 이동 로직이 없으므로, 타겟이 있는지 확인만 합니다.
+ */
+class MoveToTargetNode extends Node {
+    constructor(pathfinderEngine) {
+        super();
+        this.pathfinderEngine = pathfinderEngine;
+    }
+
+    evaluate(unit, blackboard) {
+        const target = blackboard.get('currentTargetUnit');
+        if (!target) {
+            return NodeState.FAILURE; // 타겟이 없으면 이동 실패
+        }
+
+        // TODO: PathfinderEngine을 사용하여 실제 이동 로직 구현 필요
+        // const path = this.pathfinderEngine.findPath(...);
+        // 이동이 완료되기 전까지는 NodeState.RUNNING을 반환해야 합니다.
+
+        console.log(`[AI Node] ${unit.name}: ${target.name}에게 이동을 시도합니다.`);
+        // 지금은 이동이 즉시 성공했다고 가정합니다.
+        return NodeState.SUCCESS;
+    }
+}
+
+export default MoveToTargetNode;

--- a/src/ai/nodes/Node.js
+++ b/src/ai/nodes/Node.js
@@ -1,0 +1,29 @@
+// src/ai/nodes/Node.js
+
+/**
+ * 모든 노드 상태를 정의하는 열거형(Enum) 객체입니다.
+ * @readonly
+ */
+export const NodeState = Object.freeze({
+    SUCCESS: 'SUCCESS', // 행동 성공
+    FAILURE: 'FAILURE', // 행동 실패
+    RUNNING: 'RUNNING', // 행동 진행 중
+});
+
+/**
+ * 행동 트리의 모든 노드의 기반이 되는 추상 클래스입니다.
+ * 모든 노드는 이 클래스를 상속받아 evaluate 메서드를 구현해야 합니다.
+ */
+class Node {
+    /**
+     * 이 노드의 로직을 평가하고 실행합니다.
+     * @param {object} unit - 이 트리를 실행하는 유닛
+     * @param {Blackboard} blackboard - 해당 유닛의 블랙보드
+     * @returns {NodeState} - 행동의 결과 상태
+     */
+    evaluate(unit, blackboard) {
+        throw new Error("evaluate() 메서드는 반드시 자식 클래스에서 구현되어야 합니다.");
+    }
+}
+
+export default Node;

--- a/src/ai/nodes/SelectorNode.js
+++ b/src/ai/nodes/SelectorNode.js
@@ -1,0 +1,25 @@
+// src/ai/nodes/SelectorNode.js
+
+import Node, { NodeState } from './Node.js';
+
+/**
+ * 자식 노드 중 하나라도 성공할 때까지 왼쪽에서 오른쪽으로 실행합니다. (OR 논리)
+ */
+class SelectorNode extends Node {
+    constructor(children) {
+        super();
+        this.children = children;
+    }
+
+    evaluate(unit, blackboard) {
+        for (const child of this.children) {
+            const result = child.evaluate(unit, blackboard);
+            if (result === NodeState.SUCCESS || result === NodeState.RUNNING) {
+                return result; // 하나라도 성공하거나 실행 중이면 즉시 반환
+            }
+        }
+        return NodeState.FAILURE; // 모두 실패했을 경우에만 실패 반환
+    }
+}
+
+export default SelectorNode;

--- a/src/ai/nodes/SequenceNode.js
+++ b/src/ai/nodes/SequenceNode.js
@@ -1,0 +1,25 @@
+// src/ai/nodes/SequenceNode.js
+
+import Node, { NodeState } from './Node.js';
+
+/**
+ * 모든 자식 노드가 성공해야만 성공합니다. 하나라도 실패하면 즉시 실패합니다. (AND 논리)
+ */
+class SequenceNode extends Node {
+    constructor(children) {
+        super();
+        this.children = children;
+    }
+
+    evaluate(unit, blackboard) {
+        for (const child of this.children) {
+            const result = child.evaluate(unit, blackboard);
+            if (result === NodeState.FAILURE || result === NodeState.RUNNING) {
+                return result; // 하나라도 실패하거나 실행 중이면 즉시 반환
+            }
+        }
+        return NodeState.SUCCESS; // 모두 성공했을 경우에만 성공 반환
+    }
+}
+
+export default SequenceNode;


### PR DESCRIPTION
## Summary
- implement foundational Behavior Tree classes and nodes
- create Find, Move, and Attack nodes for Warrior AI
- refactor AIManager to use behavior trees for turn execution
- update game entry to register AI with enemy lists and trigger turns

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e9df7d67483278c16a210a9659d4d