### PR TITLE
Implement basic pathfinding and battle calc worker

### DIFF
--- a/src/ai/Blackboard.js
+++ b/src/ai/Blackboard.js
@@ -35,6 +35,10 @@ class Blackboard {
         this.set('canUseSkill_1', false);        // 1번 스킬 사용 가능 여부
         this.set('canUseSkill_2', false);        // 2번 스킬 사용 가능 여부
         this.set('canUseSkill_3', false);        // 3번 스킬 사용 가능 여부
+
+        // --- 이동 및 공격 관련 신규 정보 ---
+        this.set('movementPath', null);          // 계산된 이동 경로 (좌표 배열)
+        this.set('isTargetInAttackRange', false); // 타겟이 현재 공격 범위 내에 있는지 여부
     }
 
     /**

--- a/src/ai/nodes/AttackTargetNode.js
+++ b/src/ai/nodes/AttackTargetNode.js
@@ -10,12 +10,10 @@ class AttackTargetNode extends Node {
     evaluate(unit, blackboard) {
         const target = blackboard.get('currentTargetUnit');
         if (!target) {
-            return NodeState.FAILURE; // 타겟이 없으면 공격 실패
+            return NodeState.FAILURE;
         }
 
-        // TODO: 실제 사거리 체크 로직 구현 필요
-        const isInRange = true; // 지금은 무조건 사거리 안에 있다고 가정
-
+        const isInRange = blackboard.get('isTargetInAttackRange');
         if (isInRange) {
             console.log(`[AI Node] ${unit.name}: ${target.name}을(를) 공격합니다!`);
             // EventEngine을 통해 공격 이벤트를 방송합니다.

--- a/src/ai/nodes/FindPathToTargetNode.js
+++ b/src/ai/nodes/FindPathToTargetNode.js
@@ -1,0 +1,30 @@
+// src/ai/nodes/FindPathToTargetNode.js
+
+import Node, { NodeState } from './Node.js';
+
+class FindPathToTargetNode extends Node {
+    constructor(pathfinderEngine) {
+        super();
+        this.pathfinderEngine = pathfinderEngine;
+    }
+
+    evaluate(unit, blackboard) {
+        const target = blackboard.get('currentTargetUnit');
+        if (!target) {
+            return NodeState.FAILURE;
+        }
+
+        const startCoords = { col: unit.col, row: unit.row };
+        const endCoords = { col: target.col, row: target.row };
+
+        const path = this.pathfinderEngine.findPath(startCoords, endCoords);
+        if (path) {
+            blackboard.set('movementPath', path);
+            return NodeState.SUCCESS;
+        } else {
+            return NodeState.FAILURE;
+        }
+    }
+}
+
+export default FindPathToTargetNode;

--- a/src/ai/nodes/IsTargetInRangeNode.js
+++ b/src/ai/nodes/IsTargetInRangeNode.js
@@ -1,0 +1,29 @@
+// src/ai/nodes/IsTargetInRangeNode.js
+
+import Node, { NodeState } from './Node.js';
+
+class IsTargetInRangeNode extends Node {
+    constructor(attackRange) {
+        super();
+        this.attackRange = attackRange;
+    }
+
+    evaluate(unit, blackboard) {
+        const target = blackboard.get('currentTargetUnit');
+        if (!target) {
+            return NodeState.FAILURE;
+        }
+
+        const distance = Math.abs(unit.col - target.col) + Math.abs(unit.row - target.row);
+
+        if (distance <= this.attackRange) {
+            blackboard.set('isTargetInAttackRange', true);
+            return NodeState.SUCCESS;
+        } else {
+            blackboard.set('isTargetInAttackRange', false);
+            return NodeState.FAILURE;
+        }
+    }
+}
+
+export default IsTargetInRangeNode;

--- a/src/ai/nodes/MoveToTargetNode.js
+++ b/src/ai/nodes/MoveToTargetNode.js
@@ -3,27 +3,25 @@
 import Node, { NodeState } from './Node.js';
 
 /**
- * 블랙보드에 저장된 타겟에게 이동하는 행동 노드입니다.
- * 지금은 이동 로직이 없으므로, 타겟이 있는지 확인만 합니다.
+ * 블랙보드에 저장된 경로를 따라 목표 지점으로 이동하는 행동 노드입니다.
  */
 class MoveToTargetNode extends Node {
-    constructor(pathfinderEngine) {
+    constructor() {
         super();
-        this.pathfinderEngine = pathfinderEngine;
     }
 
     evaluate(unit, blackboard) {
-        const target = blackboard.get('currentTargetUnit');
-        if (!target) {
-            return NodeState.FAILURE; // 타겟이 없으면 이동 실패
+        const path = blackboard.get('movementPath');
+        if (!path || path.length === 0) {
+            return NodeState.FAILURE;
         }
 
-        // TODO: PathfinderEngine을 사용하여 실제 이동 로직 구현 필요
-        // const path = this.pathfinderEngine.findPath(...);
-        // 이동이 완료되기 전까지는 NodeState.RUNNING을 반환해야 합니다.
+        const nextStep = path.shift();
+        unit.col = nextStep.col;
+        unit.row = nextStep.row;
+        console.log(`[AI Node] ${unit.name} 이동 -> (${unit.col}, ${unit.row})`);
 
-        console.log(`[AI Node] ${unit.name}: ${target.name}에게 이동을 시도합니다.`);
-        // 지금은 이동이 즉시 성공했다고 가정합니다.
+        blackboard.set('movementPath', path.length > 0 ? path : null);
         return NodeState.SUCCESS;
     }
 }

--- a/src/engine/BattleCalculationEngine.js
+++ b/src/engine/BattleCalculationEngine.js
@@ -1,0 +1,47 @@
+// src/engine/BattleCalculationEngine.js
+
+/**
+ * 웹 워커를 사용하여 전투 계산을 비동기적으로 처리하는 엔진입니다.
+ */
+class BattleCalculationEngine {
+    constructor() {
+        this.worker = new Worker('./src/workers/BattleCalculationWorker.js', { type: 'module' });
+        this.pendingCalculations = new Map();
+    }
+
+    /**
+     * 공격자와 대상의 데이터를 워커에게 보내 데미지 계산을 요청합니다.
+     * @param {object} attacker - 공격 유닛 인스턴스
+     * @param {object} target - 대상 유닛 인스턴스
+     * @returns {Promise<object>} 계산 결과를 담은 Promise
+     */
+    calculateDamage(attacker, target) {
+        return new Promise((resolve, reject) => {
+            const calculationId = `${attacker.id}-${target.id}-${Date.now()}`;
+            this.pendingCalculations.set(calculationId, { resolve, reject });
+
+            this.worker.postMessage({
+                type: 'calculate_damage',
+                payload: { attacker, target }
+            });
+
+            this.worker.onmessage = (event) => {
+                const { type, payload } = event.data;
+                if (type === 'calculation_complete') {
+                    const promise = this.pendingCalculations.values().next().value;
+                    if (promise) {
+                        promise.resolve(payload);
+                        this.pendingCalculations.clear();
+                    }
+                }
+            };
+
+            this.worker.onerror = (error) => {
+                reject(error);
+                this.pendingCalculations.clear();
+            };
+        });
+    }
+}
+
+export default BattleCalculationEngine;

--- a/src/engine/PathfinderEngine.js
+++ b/src/engine/PathfinderEngine.js
@@ -2,21 +2,34 @@
 
 /**
  * 그리드 기반의 경로 탐색을 담당합니다.
- * A* 알고리즘 등을 사용하여 최적의 경로를 계산합니다.
  */
 class PathfinderEngine {
     /**
      * 시작 지점부터 목표 지점까지의 경로를 찾습니다.
-     * @param {object} startPos - 시작 좌표 { col, row }
-     * @param {object} endPos - 목표 좌표 { col, row }
-     * @param {object} grid - 현재 그리드 데이터
-     * @returns {Array<object> | null} 경로 좌표의 배열 또는 null
+     * 현재는 장애물을 고려하지 않고 목표에 인접한 직선 경로를 반환합니다.
+     * @param {{col: number, row: number}} startCoords - 시작 좌표 { col, row }
+     * @param {{col: number, row: number}} endCoords - 목표 좌표 { col, row }
+     * @returns {Array<{col: number, row: number}> | null} 경로 좌표의 배열 또는 null
      */
-    findPath(startPos, endPos, grid) {
-        // (경로 탐색 알고리즘은 매우 복잡하므로 나중에 구현합니다)
-        console.log(`[PathfinderEngine] (${startPos.col},${startPos.row}) 에서 (${endPos.col},${endPos.row}) 까지의 경로를 탐색합니다.`);
-        // 지금은 임시로 경로를 찾지 못했다고 가정합니다.
-        return null;
+    findPath(startCoords, endCoords) {
+        const path = [];
+        let currentCol = startCoords.col;
+        let currentRow = startCoords.row;
+
+        while (Math.abs(currentCol - endCoords.col) + Math.abs(currentRow - endCoords.row) > 1) {
+            const dx = Math.sign(endCoords.col - currentCol);
+            const dy = Math.sign(endCoords.row - currentRow);
+
+            if (dx !== 0) {
+                currentCol += dx;
+            } else if (dy !== 0) {
+                currentRow += dy;
+            }
+            path.push({ col: currentCol, row: currentRow });
+        }
+
+        console.log(`[PathfinderEngine] 경로 탐색 완료:`, path);
+        return path.length > 0 ? path : null;
     }
 }
 

--- a/src/manager/DebugBattleCalculationManager.js
+++ b/src/manager/DebugBattleCalculationManager.js
@@ -1,0 +1,23 @@
+// src/manager/DebugBattleCalculationManager.js
+
+/**
+ * 전투 계산과 관련된 모든 수치를 콘솔에 출력하여 디버깅을 돕습니다.
+ */
+class DebugBattleCalculationManager {
+    /**
+     * 데미지 계산 과정을 기록합니다.
+     * @param {object} attacker - 공격 유닛
+     * @param {object} target - 대상 유닛
+     * @param {number} damage - 계산된 데미지
+     */
+    logDamageCalculation(attacker, target, damage) {
+        console.group(`[전투 계산] ${attacker.name} -> ${target.name}`);
+        console.log(`- 공격자 힘 (Strength): ${attacker.stats.strength}`);
+        console.log(`- 대상 인내 (Endurance): ${target.stats.endurance}`);
+        console.log(`%c- 최종 데미지: ${damage}`, 'color: yellow; font-weight: bold;');
+        console.log(`- 대상 현재 HP: ${target.hp} -> ${target.hp - damage}`);
+        console.groupEnd();
+    }
+}
+
+export default DebugBattleCalculationManager;

--- a/src/manager/VFXManager.js
+++ b/src/manager/VFXManager.js
@@ -58,6 +58,21 @@ class VFXManager {
             this.updatePosition(binding.vfx, binding.sprite);
         });
     }
+
+    /**
+     * 특정 유닛의 HP 바를 업데이트합니다.
+     * @param {number} unitId - 유닛 ID
+     * @param {number} currentHp - 현재 HP
+     * @param {number} maxHp - 최대 HP
+     */
+    updateHpBar(unitId, currentHp, maxHp) {
+        const vfxContainer = this.vfxLayer.querySelector(`.vfx-container[data-unit-id="${unitId}"]`);
+        if (vfxContainer) {
+            const hpBar = vfxContainer.querySelector('.hp-bar');
+            const percentage = Math.max(0, (currentHp / maxHp) * 100);
+            hpBar.style.width = `${percentage}%`;
+        }
+    }
 }
 
 export default VFXManager;

--- a/src/workers/BattleCalculationWorker.js
+++ b/src/workers/BattleCalculationWorker.js
@@ -1,0 +1,25 @@
+// src/workers/BattleCalculationWorker.js
+
+/**
+ * Web Worker에서 실행될 전투 계산 로직입니다.
+ */
+self.onmessage = function(event) {
+    const { type, payload } = event.data;
+
+    if (type === 'calculate_damage') {
+        const { attacker, target } = payload;
+
+        const baseDamage = attacker.stats.strength;
+        const defense = target.stats.endurance;
+        const damage = Math.max(1, baseDamage - defense);
+
+        self.postMessage({
+            type: 'calculation_complete',
+            payload: {
+                attackerId: attacker.id,
+                targetId: target.id,
+                damageDealt: damage
+            }
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- implement simple straight-line PathfinderEngine
- extend Blackboard with path and attack range status
- update MoveToTargetNode and AttackTargetNode to use blackboard data
- add nodes for checking range and finding paths
- build melee behavior tree in AIManager
- add worker-based battle calculation engine and debug manager
- add HP bar updater in VFXManager

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f1db90c3c83278679d3a9bd02f559