### PR TITLE
Fix movement final position

### DIFF
--- a/src/engine/AnimationEngine.js
+++ b/src/engine/AnimationEngine.js
@@ -38,9 +38,8 @@ class AnimationEngine {
                 if (progress < 1) {
                     requestAnimationFrame(animate);
                 } else {
+                    // 애니메이션이 끝나면 transform만 초기화합니다.
                     element.style.transform = '';
-                    element.style.left = `${endPos.x}px`;
-                    element.style.top = `${endPos.y}px`;
                     resolve();
                 }
             };

--- a/src/engine/FormationEngine.js
+++ b/src/engine/FormationEngine.js
@@ -57,6 +57,9 @@ class FormationEngine {
                 onUpdate,
             )
             .then(() => {
+                unitSprite.style.left = `${endPos.x}px`;
+                unitSprite.style.top = `${endPos.y}px`;
+
                 const unitId = unitSprite.dataset.unitId;
                 this.grid.set(`${endCoords.col},${endCoords.row}`, unitId);
 


### PR DESCRIPTION
## Summary
- clean up AnimationEngine to stop adjusting `left`/`top`
- update FormationEngine so unit sprites set their final absolute position after animation completes

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687f247781088327bff1d5c1d35dc474